### PR TITLE
Support maxSdkVersion

### DIFF
--- a/library/src/main/java/permissions/dispatcher/NeedsPermission.java
+++ b/library/src/main/java/permissions/dispatcher/NeedsPermission.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.CLASS)
 public @interface NeedsPermission {
     String[] value();
+    int maxSdkVersion() default 0;
 }

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
@@ -141,7 +141,7 @@ abstract class BaseProcessorUnit : ProcessorUnit {
         val requestCodeField = requestCodeFieldName(needsMethod)
         val permissionField = permissionFieldName(needsMethod)
 
-        // if maxSdkVersion is lower than os level don't check permission
+        // if maxSdkVersion is lower than os level does nothing
         val needsPermissionMaxSdkVersion = needsMethod.getAnnotation(NeedsPermission::class.java).maxSdkVersion
         if (needsPermissionMaxSdkVersion > 0) {
             builder.beginControlFlow("if (\$T.VERSION.SDK_INT > \$L)", BUILD, needsPermissionMaxSdkVersion)

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
@@ -20,7 +20,7 @@ import javax.lang.model.element.Modifier
 abstract class BaseProcessorUnit : ProcessorUnit {
 
     protected val PERMISSION_UTILS = ClassName.get("permissions.dispatcher", "PermissionUtils")
-    private val SDK_INT = ClassName.get("android.os", "Build")
+    private val BUILD = ClassName.get("android.os", "Build")
     private val MANIFEST_WRITE_SETTING = "android.permission.WRITE_SETTINGS"
     private val MANIFEST_SYSTEM_ALERT_WINDOW = "android.permission.SYSTEM_ALERT_WINDOW"
     private val ADD_WITH_CHECK_BODY_MAP = hashMapOf(MANIFEST_SYSTEM_ALERT_WINDOW to SystemAlertWindowHelper(), MANIFEST_WRITE_SETTING to WriteSettingsHelper())
@@ -144,7 +144,7 @@ abstract class BaseProcessorUnit : ProcessorUnit {
         // if maxSdkVersion is lower than os level don't check permission
         val needsPermissionMaxSdkVersion = needsMethod.getAnnotation(NeedsPermission::class.java).maxSdkVersion
         if (needsPermissionMaxSdkVersion > 0) {
-            builder.beginControlFlow("if (\$T.VERSION.SDK_INT > \$L)", SDK_INT, needsPermissionMaxSdkVersion)
+            builder.beginControlFlow("if (\$T.VERSION.SDK_INT > \$L)", BUILD, needsPermissionMaxSdkVersion)
                     .addCode(CodeBlock.builder()
                             .add("\$N.\$N(", targetParam, needsMethod.simpleString())
                             .add(varargsParametersCodeBlock(needsMethod))

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
@@ -144,12 +144,12 @@ abstract class BaseProcessorUnit : ProcessorUnit {
         // if maxSdkVersion is lower than os level don't check permission
         val needsPermissionMaxSdkVersion = needsMethod.getAnnotation(NeedsPermission::class.java).maxSdkVersion
         if (needsPermissionMaxSdkVersion > 0) {
-            builder.beginControlFlow("if (\$T.VERSION.SDK_INT > \$L}", SDK_INT, needsPermissionMaxSdkVersion)
+            builder.beginControlFlow("if (\$T.VERSION.SDK_INT > \$L)", SDK_INT, needsPermissionMaxSdkVersion)
                     .addCode(CodeBlock.builder()
                             .add("\$N.\$N(", targetParam, needsMethod.simpleString())
                             .add(varargsParametersCodeBlock(needsMethod))
-                            .addStatement("return")
                             .addStatement(")")
+                            .addStatement("return")
                             .build())
                     .endControlFlow()
         }

--- a/processor/src/test/java/permissions/dispatcher/processor/ProcessorTestSuite.java
+++ b/processor/src/test/java/permissions/dispatcher/processor/ProcessorTestSuite.java
@@ -1,6 +1,7 @@
 package permissions.dispatcher.processor;
 
 import org.junit.Test;
+
 import permissions.dispatcher.processor.base.TestSuite;
 import permissions.dispatcher.processor.data.Source;
 
@@ -310,6 +311,14 @@ public class ProcessorTestSuite extends TestSuite {
     @Test public void noDuplicatesDespiteRepeatedValuesActivity() {
         // Issue 63: https://github.com/hotchemi/PermissionsDispatcher/issues/63
         assertJavaSource(Source.NoDuplicatesDespiteRepeatedValuesActivity);
+    }
+
+    @Test public void validMaxSdkVersion() {
+        assertJavaSource(Source.ValidMaxSdkVersion);
+    }
+
+    @Test public void invalidMaxSdkVersion() {
+        assertJavaSource(Source.InValidMaxSdkVersion);
     }
 
     @Test public void writeSettingsSupportFragment() {

--- a/processor/src/test/java/permissions/dispatcher/processor/data/Source.java
+++ b/processor/src/test/java/permissions/dispatcher/processor/data/Source.java
@@ -4961,6 +4961,163 @@ public final class Source {
         }
     };
 
+    public static final BaseTest ValidMaxSdkVersion = new BaseTest() {
+        @Override
+        protected String getName() {
+            return "MyActivity";
+        }
+
+        @Override
+        protected String[] getActualSource() {
+            return new String[]{
+                    "package tests;",
+                    "import android.Manifest;",
+                    "import android.app.Activity;",
+                    "import permissions.dispatcher.RuntimePermissions;",
+                    "import permissions.dispatcher.NeedsPermission;",
+                    "import permissions.dispatcher.OnPermissionDenied;",
+                    "import permissions.dispatcher.OnNeverAskAgain;",
+                    "@RuntimePermissions",
+                    "public class MyActivity extends Activity {",
+                    "   @NeedsPermission(value = Manifest.permission.WRITE_EXTERNAL_STORAGE, maxSdkVersion = 18)",
+                    "   void showGetStorage() {",
+                    "   }",
+                    "   @OnPermissionDenied(Manifest.permission.WRITE_EXTERNAL_STORAGE)",
+                    "   void onGetStorageDenied() {",
+                    "   }",
+                    "   @OnNeverAskAgain(Manifest.permission.WRITE_EXTERNAL_STORAGE)",
+                    "   void onGetStorageNeverAsk() {",
+                    "   }",
+                    "}"
+            };
+        }
+
+        @Override
+        protected String[] getExpectSource() {
+            return new String[]{
+                    "package tests;",
+                    "import android.os.Build;",
+                    "import android.support.v4.app.ActivityCompat;",
+                    "import java.lang.String;",
+                    "import permissions.dispatcher.PermissionUtils;",
+                    "final class MyActivityPermissionsDispatcher {",
+                    "   private static final int REQUEST_SHOWGETSTORAGE = 0;",
+                    "   private static final String[] PERMISSION_SHOWGETSTORAGE = new String[] {\"android.permission.WRITE_EXTERNAL_STORAGE\"};",
+                    "   private MyActivityPermissionsDispatcher() {",
+                    "   }",
+                    "   static void showGetStorageWithCheck(MyActivity target) {",
+                    "       if (Build.VERSION.SDK_INT > 18) {",
+                    "           target.showGetStorage();",
+                    "           return;",
+                    "       }",
+                    "       if (PermissionUtils.hasSelfPermissions(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "           target.showGetStorage();",
+                    "       } else {",
+                    "           ActivityCompat.requestPermissions(target, PERMISSION_SHOWGETSTORAGE, REQUEST_SHOWGETSTORAGE);",
+                    "       }",
+                    "   }",
+                    "   static void onRequestPermissionsResult(MyActivity target, int requestCode, int[] grantResults) {",
+                    "       switch (requestCode) {",
+                    "           case REQUEST_SHOWGETSTORAGE:",
+                    "               if (PermissionUtils.getTargetSdkVersion(target) < 23 && !PermissionUtils.hasSelfPermissions(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "                   target.onGetStorageDenied();",
+                    "                   return;",
+                    "               }",
+                    "               if (PermissionUtils.verifyPermissions(grantResults)) {",
+                    "                   target.showGetStorage();",
+                    "               } else {",
+                    "                   if (!PermissionUtils.shouldShowRequestPermissionRationale(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "                       target.onGetStorageNeverAsk();",
+                    "                   } else {",
+                    "                       target.onGetStorageDenied();",
+                    "                   }",
+                    "               }",
+                    "               break;",
+                    "           default:",
+                    "               break;",
+                    "       }",
+                    "   }",
+                    "}"
+            };
+        }
+    };
+
+    public static final BaseTest InValidMaxSdkVersion = new BaseTest() {
+        @Override
+        protected String getName() {
+            return "MyActivity";
+        }
+
+        @Override
+        protected String[] getActualSource() {
+            return new String[]{
+                    "package tests;",
+                    "import android.Manifest;",
+                    "import android.app.Activity;",
+                    "import permissions.dispatcher.RuntimePermissions;",
+                    "import permissions.dispatcher.NeedsPermission;",
+                    "import permissions.dispatcher.OnPermissionDenied;",
+                    "import permissions.dispatcher.OnNeverAskAgain;",
+                    "@RuntimePermissions",
+                    "public class MyActivity extends Activity {",
+                    "   @NeedsPermission(value = Manifest.permission.WRITE_EXTERNAL_STORAGE, maxSdkVersion = 0)",
+                    "   void showGetStorage() {",
+                    "   }",
+                    "   @OnPermissionDenied(Manifest.permission.WRITE_EXTERNAL_STORAGE)",
+                    "   void onGetStorageDenied() {",
+                    "   }",
+                    "   @OnNeverAskAgain(Manifest.permission.WRITE_EXTERNAL_STORAGE)",
+                    "   void onGetStorageNeverAsk() {",
+                    "   }",
+                    "}"
+            };
+        }
+
+        @Override
+        protected String[] getExpectSource() {
+            return new String[]{
+                    "package tests;",
+                    "import android.support.v4.app.ActivityCompat;",
+                    "import java.lang.String;",
+                    "import permissions.dispatcher.PermissionUtils;",
+                    "final class MyActivityPermissionsDispatcher {",
+                    "   private static final int REQUEST_SHOWGETSTORAGE = 0;",
+                    "   private static final String[] PERMISSION_SHOWGETSTORAGE = new String[] {\"android.permission.WRITE_EXTERNAL_STORAGE\"};",
+                    "   private MyActivityPermissionsDispatcher() {",
+                    "   }",
+                    "   static void showGetStorageWithCheck(MyActivity target) {",
+                    "       if (PermissionUtils.hasSelfPermissions(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "           target.showGetStorage();",
+                    "       } else {",
+                    "           ActivityCompat.requestPermissions(target, PERMISSION_SHOWGETSTORAGE, REQUEST_SHOWGETSTORAGE);",
+                    "       }",
+                    "   }",
+                    "   static void onRequestPermissionsResult(MyActivity target, int requestCode, int[] grantResults) {",
+                    "       switch (requestCode) {",
+                    "           case REQUEST_SHOWGETSTORAGE:",
+                    "               if (PermissionUtils.getTargetSdkVersion(target) < 23 && !PermissionUtils.hasSelfPermissions(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "                   target.onGetStorageDenied();",
+                    "                   return;",
+                    "               }",
+                    "               if (PermissionUtils.verifyPermissions(grantResults)) {",
+                    "                   target.showGetStorage();",
+                    "               } else {",
+                    "                   if (!PermissionUtils.shouldShowRequestPermissionRationale(target, PERMISSION_SHOWGETSTORAGE)) {",
+                    "                       target.onGetStorageNeverAsk();",
+                    "                   } else {",
+                    "                       target.onGetStorageDenied();",
+                    "                   }",
+                    "               }",
+                    "               break;",
+                    "           default:",
+                    "               break;",
+                    "       }",
+                    "   }",
+                    "}"
+            };
+        }
+    };
+
     public static final BaseTest DuplicatesInListsActivity = new BaseTest() {
         @Override
         protected String getName() {


### PR DESCRIPTION
ref: https://github.com/hotchemi/PermissionsDispatcher/issues/192
ref: https://developer.android.com/guide/topics/manifest/uses-permission-element.html

## Change

- Add maxSdkVersionSupport.
  - Add `maxSdkVersion` in NeedsPermission.java
  - If specified value is above 0, processor creates code that only checks SDK_INT and call needs permission method.
  - If specified value is 0 or below, it does nothing.