### PR TITLE
Add @NonNull annotations for onRequestPermissionsResult example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ protected void onCreate(Bundle savedInstanceState) {
 }
 
 @Override
-public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     // NOTE: delegate the permission handling to generated method
     MainActivityPermissionsDispatcher.onRequestPermissionsResult(this, requestCode, grantResults);


### PR DESCRIPTION
To avoid lint warning.