### PR TITLE
Use JFrog's artifactory plugin to upload snaphots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ branches:
 
 script: ./gradlew check --stacktrace
 
+after_success:
+  - "./deploy_snapshot.sh"
+
 deploy:
   provider: script
   script: ./release.sh

--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ buildscript {
 }
 ```
 
+Snapshots of the development version are available in [JFrog's snapshots repository](https://oss.jfrog.org/oss-snapshot-local/)). 
+Add the repo below to download `SNAPSHOT` releases.
+
+```groovy
+repositories {
+  jcenter()
+  maven { url 'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+}
+```
+
 And on your **app module** `build.gradle`:
 
 `${latest.version}` is [![Download](https://api.bintray.com/packages/hotchemi/maven/permissionsdispatcher/images/download.svg)](https://bintray.com/hotchemi/maven/permissionsdispatcher/_latestVersion)

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ buildscript {
         classpath "com.neenbedankt.gradle.plugins:android-apt:$APT_PLUGIN_VERSION"
         classpath "com.novoda:bintray-release:$BINTRAY_PLUGIN_VERSION"
         classpath "com.netflix.nebula:gradle-extra-configurations-plugin:$CONFIG_PLUGIN_VERSION"
+        // Need this to publish SNAPSHOTs to JFrog
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:$JFROG_PLUGIN_VERSION"
     }
 }
 

--- a/deploy_snapshot.sh
+++ b/deploy_snapshot.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Deploy a jar, source jar, and javadoc jar to Sonatype's snapshot repo.
+#
+# Adapted from https://coderwall.com/p/9b_lfq and
+# http://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
+
+SLUG="hotchemi/PermissionsDispatcher"
+JDK="oraclejdk8"
+BRANCH="master"
+
+set -e
+
+if [ "$TRAVIS_REPO_SLUG" != "$SLUG" ]; then
+  echo "Skipping snapshot deployment: wrong repository. Expected '$SLUG' but was '$TRAVIS_REPO_SLUG'."
+elif [ "$TRAVIS_JDK_VERSION" != "$JDK" ]; then
+  echo "Skipping snapshot deployment: wrong JDK. Expected '$JDK' but was '$TRAVIS_JDK_VERSION'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+  echo "Skipping snapshot deployment: was pull request."
+elif [ "$TRAVIS_BRANCH" != "$BRANCH" ]; then
+  echo "Skipping snapshot deployment: wrong branch. Expected '$BRANCH' but was '$TRAVIS_BRANCH'."
+else
+  echo "Deploying snapshot..."
+  ./gradlew artifactoryPublish
+  echo "Snapshot deployed!"
+fi

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ USER = hotchemi
 GROUP_ID = com.github.hotchemi
 ARTIFACT_ID_LIBRARY = permissionsdispatcher
 ARTIFACT_ID_PROCESSOR = permissionsdispatcher-processor
-VERSION = 2.3.0
+VERSION = 2.3.0-SNAPSHOT
 DESCRIPTION = Annotation-based library for generating runtime permissions dispatcher.
 WEBSITE = https://github.com/hotchemi/PermissionsDispatcher
 LICENCES = ['Apache-2.0']
@@ -16,6 +16,7 @@ KOTLIN_VERSION=1.0.5
 APT_PLUGIN_VERSION=1.8
 BINTRAY_PLUGIN_VERSION=0.3.4
 CONFIG_PLUGIN_VERSION=2.2.2
+JFROG_PLUGIN_VERSION=4.1.1
 
 # Dependency versions
 SUPPORT_LIBRARY_VERSION=23.1.1

--- a/gradle/gradle-artifactory-upload.gradle
+++ b/gradle/gradle-artifactory-upload.gradle
@@ -1,0 +1,18 @@
+apply plugin: 'com.jfrog.artifactory'
+
+artifactory {
+    contextUrl = 'https://oss.jfrog.org/artifactory'
+    publish {
+        repository {
+            // The Artifactory repository key to publish to
+            repoKey = VERSION.endsWith('SNAPSHOT') ? 'oss-snapshot-local' : 'oss-release-local'
+            username = System.getenv('bintrayUser') // The publisher user name
+            password = System.getenv('bintrayKey') // The publisher password
+            maven = true
+        }
+        defaults {
+            publishArtifacts = true
+            publications('maven')
+        }
+    }
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -93,3 +93,5 @@ project.afterEvaluate {
     def compileLintTask = project.tasks.find { it.name == 'compileLint' }
     compileLintTask.dependsOn(copyLintJar)
 }
+
+apply from: rootProject.file('gradle/gradle-artifactory-upload.gradle')

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -86,3 +86,5 @@ publish {
     website = WEBSITE
     licences = LICENCES
 }
+
+apply from: rootProject.file('gradle/gradle-artifactory-upload.gradle')


### PR DESCRIPTION
Fixes #232 

Changes here include:

- Add a deploy script that uploads snapshots of master to jfrog
- Add SNAPSHOT to current version number of the library

Todo from project maintainer

- [ ] Create an OJO account. 
- [ ] Make a snapshot release.
- [x] Unbreak test.

Since you have a bintray account already you don't have to manually create the OJO account. Follow [this](https://www.jfrog.com/confluence/display/RTF/Deploying+Snapshots+to+oss.jfrog.org#DeployingSnapshotstooss.jfrog.org-GettingStartedwithOJO) It's some clicks away.