### PR TITLE
Fix the condition of handling Xiaomi phone

### DIFF
--- a/library/src/main/android/permissions/dispatcher/PermissionUtils.java
+++ b/library/src/main/android/permissions/dispatcher/PermissionUtils.java
@@ -96,7 +96,7 @@ public final class PermissionUtils {
      * @see #hasSelfPermissions(Context, String...)
      */
     private static boolean hasSelfPermission(Context context, String permission) {
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M && "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER)) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER)) {
             return hasSelfPermissionForXiaomi(context, permission);
         }
         try {


### PR DESCRIPTION
Close #240

According to https://github.com/a1018875550/PermissionDispatcher/blob/master/library/src/main/android/org.jokar.permissiondispatcher.library/PermissionUtils.java#L129, I think `Build.VERSION_CODES.M` should be included for handling Xiaomi device's runtime permission.

#242 block this pull request. It should fix the problem with test failure.