### PR TITLE
Handle the case Build.MANUFACTURER = null

### DIFF
--- a/library/src/main/android/permissions/dispatcher/PermissionUtils.java
+++ b/library/src/main/android/permissions/dispatcher/PermissionUtils.java
@@ -96,7 +96,7 @@ public final class PermissionUtils {
      * @see #hasSelfPermissions(Context, String...)
      */
     private static boolean hasSelfPermission(Context context, String permission) {
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M && Build.MANUFACTURER.equalsIgnoreCase("Xiaomi")) {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.M && "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER)) {
             return hasSelfPermissionForXiaomi(context, permission);
         }
         try {


### PR DESCRIPTION
I hope it doesn't happen in real world, but if `Build.MANUFACTURER` is null, the condition give us NullPointerException. We should avoid the unexpected Exception.