### PR TITLE
Remove un-existing method call.

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,10 +78,6 @@ artifacts {
     archives sourcesJar
 }
 
-assemble.doLast {
-    copyJarToOtherModules.execute()
-}
-
 task copyLintJar(type: Copy) {
     from(configurations.lintChecks) {
         rename { 'lint.jar' }


### PR DESCRIPTION
Closes https://github.com/hotchemi/PermissionsDispatcher/issues/255.

`copyJarToOtherModules` method is no longer existing so I removed calling of it.