### PR TITLE
Escape less than and greater than

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ That's it!
 
 ## maxSdkVersion
 
-[<uses-permission>](https://developer.android.com/guide/topics/manifest/uses-permission-element.html) has an attribute call `maxSdkVersion`. PermissionsDispatcher support the feature as well.
+[\<uses-permission\>](https://developer.android.com/guide/topics/manifest/uses-permission-element.html) has an attribute call `maxSdkVersion`. PermissionsDispatcher support the feature as well.
 
 The following sample is for declaring `Manifest.permisison.WRITE_EXTERNAL_STORAGE` up to API level 18.
 


### PR DESCRIPTION
use-permission link didn't show up