### PR TITLE
Fix incorrect compile statement on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ To add it to your project, include the following in your **app module** `build.g
 
 ```groovy
 dependencies {
-  compile 'com.github.hotchemi:permissionsdispatcher:${latest.version}' {
+  compile('com.github.hotchemi:permissionsdispatcher:${latest.version}') {
       // if you don't use android.app.Fragment you can exclude support for them
       exclude module: "support-v13"
   }


### PR DESCRIPTION
I found that `compile` statement in README cause compile error below.

```
> Could not find method com.github.hotchemi:permissionsdispatcher:2.4.0() for arguments [build_bntcqky9u06m4fd4spdo1j79y$_run_closure4$_closure30@77c02cb] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

When we use closure after the artifact, we should put artifact in parenthesis.