### PR TITLE
Added a notice for Jitpack users to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ repositories {
 }
 ```
 
+### For Jitpack users
+
+If you include [Jitpack.io](https://jitpack.io/) dependencies in your project, it is important to review the order of the repositories available to your app module. Because of the library's artifact ID, Jitpack might be tempted to resolve the dependency on its own, which could lead to an error during Gradle's configuration time:
+
+```
+Error: Module depends on one or more Android Libraries but is a jar
+```
+
+In short, please ensure that the `jcenter()` repository is located *above* Jitpack's repository in your `repositories` block!
+
 ## Licence
 
 ```


### PR DESCRIPTION
* related to #315, Jitpack causes an error when it tries to resolve PD's dependency itself
* users need to change the order of repositories available to their project, so that jcenter takes precedence