### PR TITLE
Allow for Deterministic, Reproducible Builds with sorted inputs

### DIFF
--- a/processor/src/main/kotlin/permissions/dispatcher/processor/PermissionsProcessor.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/PermissionsProcessor.kt
@@ -59,17 +59,21 @@ class PermissionsProcessor : AbstractProcessor() {
         // Create a RequestCodeProvider which guarantees unique request codes for each permission request
         val requestCodeProvider = RequestCodeProvider()
 
-        roundEnv.getElementsAnnotatedWith(RuntimePermissions::class.java).forEach {
-            // Find a suitable ProcessorUnit for this element
-            val processorUnit = findAndValidateProcessorUnit(processorUnits, it)
+        // The Set of annotated elements needs to be ordered
+        // in order to achieve Deterministic, Reproducible Builds
+        roundEnv.getElementsAnnotatedWith(RuntimePermissions::class.java)
+                .sortedBy { it.simpleName.toString() }
+                .forEach {
+                    // Find a suitable ProcessorUnit for this element
+                    val processorUnit = findAndValidateProcessorUnit(processorUnits, it)
 
-            // Create a RuntimePermissionsElement for this value
-            val rpe = RuntimePermissionsElement(it as TypeElement)
+                    // Create a RuntimePermissionsElement for this value
+                    val rpe = RuntimePermissionsElement(it as TypeElement)
 
-            // Create a JavaFile for this element and write it out
-            val javaFile = processorUnit.createJavaFile(rpe, requestCodeProvider)
-            javaFile.writeTo(filer)
-        }
+                    // Create a JavaFile for this element and write it out
+                    val javaFile = processorUnit.createJavaFile(rpe, requestCodeProvider)
+                    javaFile.writeTo(filer)
+                }
 
         return true
     }

--- a/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
+++ b/processor/src/main/kotlin/permissions/dispatcher/processor/impl/BaseProcessorUnit.kt
@@ -59,7 +59,10 @@ abstract class BaseProcessorUnit : ProcessorUnit {
 
     private fun createFields(needsElements: List<ExecutableElement>, requestCodeProvider: RequestCodeProvider): List<FieldSpec> {
         val fields: ArrayList<FieldSpec> = arrayListOf()
-        needsElements.forEach {
+
+        // The Set of annotated elements needs to be ordered
+        // in order to achieve Deterministic, Reproducible Builds
+        needsElements.sortedBy { it.simpleString() }.forEach {
             // For each method annotated with @NeedsPermission, add REQUEST integer and PERMISSION String[] fields
             fields.add(createRequestCodeField(it, requestCodeProvider.nextRequestCode()))
             fields.add(createPermissionField(it))


### PR DESCRIPTION
The annotation processor uses a RequestCodeProvider to assign unique
request codes to each annotated @NeedsPermission method. This shared
state collides with the non-deterministic nature of the processor's
RoundEnvironment, since we can't guarantee the processing order by default.

Here, we sort the affected sets of data before starting the iterations.
First, the annotated @RuntimePermissions classes need to be in the same
order every time we build. Second, inside each annotated class, the
annotated @NeedsPermission methods also need to be in the same order.
Using simple "sortedBy" predicates, this is achieved.

fixes #318 

---

Im unsure if it's possible to unit test this. We could implement JUnit's `@Repeat` with a less trivial set of inputs, and check that the output is the same every time after n iterations. I'm unconvinced that this would greatly improve the quality of our product, though, so I'd suggest we leave it be.